### PR TITLE
Fix: Better paths, devcontainer, minor Readme fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+	"postCreateCommand": "sudo apt update && sudo apt install -y python3-pyaudio"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="https://github.com/wavify-labs/wavify-sdks/blob/main/assets/wavify-black-pink-word.svg">
       <source media="(prefers-color-scheme: dark)" srcset="https://github.com/wavify-labs/wavify-sdks/blob/main/assets/wavify-white-pink-word.svg">
-      <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/main/public/logo/nixos-hires.png" width="500px" alt="NixOS logo">
+      <img src="https://github.com/wavify-labs/wavify-sdks/blob/main/assets/wavify-white-pink-word.svg" width="500px" alt="Wavify logo">
     </picture>
   </a>
 </p>

--- a/demos/python-demo/speech-to-text.py
+++ b/demos/python-demo/speech-to-text.py
@@ -6,12 +6,16 @@ from wavify.stt import SttEngine
 from wavify.utils import LogLevel, set_log_level
 
 set_log_level(LogLevel.DEBUG)
-engine = SttEngine("../../models/model-en.bin", os.getenv("WAVIFY_API_KEY"))
+
+model_path = Path(__file__).parent.parent.parent / "models" / "model-en.bin"
+wav_path = Path(__file__).parent.parent.parent / "assets" / "samples_jfk.wav"
+
+engine = SttEngine(model_path.as_posix(), os.getenv("WAVIFY_API_KEY"))
 
 now = time()
-result_file = engine.stt_from_file(
-    Path(__file__).parent.parent.parent / "assets" / "samples_jfk.wav"
-)
+result_file = engine.stt_from_file(wav_path)
+
 print(result_file)
 print(f"Took {time()-now}s")
+
 engine.destroy()


### PR DESCRIPTION
- All paths in python STT demo using the same syntax and in one place
- Add a .devcontainer for easier onboarding
- Minor README fix to use the Wavify logo as the default (I was just confused when I first read NixOS, but I realize that it doesn't change anything)

TODO: The demo still fails to run in a devcontainer/docker because `/etc/machine-id` isn't set. It might be useful for future CI/CD work to make this work inside a container some other way.